### PR TITLE
update eslint to prevent warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In root, create a file named `.eslintrc` and add:
     "allowTemplateLiterals": true
   },
   "rules": {
-    "no-console": [1, { "allow": ["error"] }],
+    "no-console": [1, { "allow": ["warn", "error"] }],
     "no-debugger": 1,
     "class-methods-use-this": 0,
     "linebreak-style": 0,


### PR DESCRIPTION
There was a recent update that throws lots of warnings on the console when using this webpack coding, so the change was made to use a specific version of eslint.